### PR TITLE
Num Steps Prior Fix and other bugfixes

### DIFF
--- a/attend_infer_repeat/cell.py
+++ b/attend_infer_repeat/cell.py
@@ -64,7 +64,7 @@ class AIRCell(snt.RNNCore):
             self._glimpse_encoder = glimpse_encoder()
             self._glimpse_decoder = glimpse_decoder(crop_size)
 
-            self._what_distrib = ParametrisedGaussian(n_appearance, scale_offset=-1.,
+            self._what_distrib = ParametrisedGaussian(n_appearance, scale_offset=0.5,
                                                       validate_args=self._debug, allow_nan_stats=not self._debug)
 
             self._steps_predictor = steps_predictor()
@@ -143,8 +143,7 @@ class AIRCell(snt.RNNCore):
             presence_prob = self._steps_predictor(hidden_output)
 
             if self._explore_eps is not None:
-                clipped_prob = tf.clip_by_value(presence_prob, self._explore_eps, 1. - self._explore_eps)
-                presence_prob = tf.stop_gradient(clipped_prob - presence_prob) + presence_prob
+                presence_prob = self._explore_eps / 2 + (1 - self._explore_eps) * presence_prob
 
             if self._sample_presence:
                 presence_distrib = Bernoulli(probs=presence_prob, dtype=tf.float32,

--- a/attend_infer_repeat/evaluation.py
+++ b/attend_infer_repeat/evaluation.py
@@ -233,7 +233,10 @@ def gradient_summaries(gvs, norm=True, ratio=True, histogram=True):
         tf.summary.scalar('grad_norm', grad_norm)
 
     for g, v in gvs:
-        var_name = v.name.split(':')[-1]
+        var_name = v.name.split(':')[0]
+        if g is None:
+            print 'Gradient for variable {} is None'.format(var_name)
+            continue
 
         if ratio:
             log_ratio((g, v), '/'.join(('grad_ratio', var_name)))

--- a/attend_infer_repeat/modules.py
+++ b/attend_infer_repeat/modules.py
@@ -1,6 +1,8 @@
 import numpy as np
 import tensorflow as tf
 from tensorflow.contrib.distributions import NormalWithSoftplusScale
+from tensorflow.python.util import nest
+
 import sonnet as snt
 
 from neural import MLP
@@ -126,10 +128,13 @@ class BaselineMLP(snt.AbstractModule):
         super(BaselineMLP, self).__init__(self.__class__.__name__)
         self._n_hidden = n_hidden
 
-    def _build(self, img, what, where, presence_prob):
+    def _build(self, img, what, where, presence_prob, state=None):
 
         batch_size = int(img.get_shape()[0])
         parts = [tf.reshape(tf.transpose(i, (1, 0, 2)), (batch_size, -1)) for i in (what, where, presence_prob)]
+        if state is not None:
+            parts += nest.flatten(state)
+
         img_flat = tf.reshape(img, (batch_size, -1))
         baseline_inpts = [img_flat] + parts
         baseline_inpts = tf.concat(baseline_inpts, -1)

--- a/attend_infer_repeat/neural.py
+++ b/attend_infer_repeat/neural.py
@@ -79,7 +79,7 @@ class MLP(snt.AbstractModule):
             assert len(transfers) == len(self._n_hiddens)
         else:
             transfers *= len(self._n_hiddens)
-        self._hidden_transfers = nest.flatten(hidden_transfer)
+        self._hidden_transfers = nest.flatten(transfers)
         self._n_out = n_out
         self._transfer = transfer
         self._initializers = initializers

--- a/attend_infer_repeat/prior.py
+++ b/attend_infer_repeat/prior.py
@@ -22,6 +22,7 @@ def masked_apply(tensor, op, mask):
 
 
 def geometric_prior(success_prob, n_steps):
+    success_prob = tf.clip_by_value(success_prob, 1e-7, 1. - 1e-15)
     geom = Geometric(probs=1. - success_prob)
     events = tf.range(n_steps + 1, dtype=geom.dtype)
     probs = geom.prob(events)

--- a/test/prior_test.py
+++ b/test/prior_test.py
@@ -1,7 +1,7 @@
 import numpy as np
 import unittest
 
-from numpy.testing import assert_array_equal
+from numpy.testing import assert_array_equal, assert_array_almost_equal
 from testing_tools import TFTestBase
 
 from attend_infer_repeat.prior import *
@@ -10,15 +10,18 @@ from attend_infer_repeat.prior import *
 _N_STRESS_ITER = 100
 
 
-class GeometricPriorTest(unittest.TestCase):
+class GeometricPriorTest(TFTestBase):
 
     def test(self):
-        p = geometric_prior(.25, 3)
-        self.assertEqual(p.shape, (4,))
-        self.assertTrue(.5 < p[0] < .75)
-        self.assertTrue(.2 < p[1] < .25)
-        self.assertTrue(.24**2 < p[2] < .25**2)
-        self.assertTrue(.24**3 < p[3] < .25**3)
+        prob = .75
+        # prob = 1. - 1e-15
+        # prob = 1e-7
+        n_steps = 10
+        expected = (1. - prob) * prob ** np.arange(n_steps + 1)
+        p = geometric_prior(prob, n_steps)
+        p = self.eval(p)
+        print p, p.sum()
+        assert_array_almost_equal(p, expected)
 
 
 class TabularKLTest(TFTestBase):


### PR DESCRIPTION
The original paper uses a geometric prior, whereas the implementation here used a stick-breaking process prior with the form of the approximate posterior distribution. The prior here is restored to a geometric one, which for big values of success probability resembles a high-entropy uniform prior at the start of training, which encourages exploration in the number of steps.

Other fixes:
* MLP bug fix: every MLP had only a single hidden layer